### PR TITLE
Improve Supabase authentication handling

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -4,40 +4,43 @@ import React, { useContext, useState } from "react";
 import { StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-native";
 import { AuthContext } from "../contexts/AuthContext";
 
-export default function login() {
+export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const context = useContext(AuthContext); // Acceder al contexto de autenticación
+  const { login, isLoading } = useContext(AuthContext);
   const router = useRouter();
-   
+
 
 
   const handleLogin = async () => {
-    console.log("Login", { email, password });
-    const success = await context.login(email, password);
+    const sanitizedEmail = email.trim();
+
+    if (!sanitizedEmail || !password) {
+      setErrorMessage("Ingresa tu correo y contraseña.");
+      return;
+    }
+
+    setErrorMessage(null);
+
+    const success = await login(sanitizedEmail, password);
+
     if (success) {
       router.push("/(main)/home");
+      return;
     }
-  };
-  const handleLogin1 = async () => {
-    const success = await context.login(email, password);
-    if (success) {
-      console.log("Login successful");
-    }
+
+    setErrorMessage("Correo o contraseña incorrectos.");
   };
 
-  const hola= async()=>{
-    router.push("/(main)/home")}
-
-  const handleRegister = () => {
-    console.log("Register", { email, password });
-    context.register(email, password);
+  const handleAppleLogin = async () => {
+    router.push("/(main)/home");
   };
 
   return (
     <View style={styles.container}>
-      <Image 
+      <Image
         source={require('@/assets/images/Logo.png')}
         style={styles.logo}
       />
@@ -58,14 +61,16 @@ export default function login() {
         value={email}                  
         onChangeText={setEmail}        
       />
-      <TextInput 
-        style={styles.input} 
-        placeholder="Contraseña" 
-        secureTextEntry 
+      <TextInput
+        style={styles.input}
+        placeholder="Contraseña"
+        secureTextEntry
         placeholderTextColor="#888"
-        value={password}               
-        onChangeText={setPassword}    
+        value={password}
+        onChangeText={setPassword}
       />
+
+      {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
 
       <View style={styles.rememberContainer}>
         <TouchableOpacity style={styles.checkbox} />
@@ -76,17 +81,25 @@ export default function login() {
       </View>
 
       <TouchableOpacity
-        style={styles.buttonAlt}
+        style={[
+          styles.buttonAlt,
+          isLoading ? styles.buttonDisabled : null,
+        ]}
         activeOpacity={0.8}
-        onPress={handleLogin1}          
+        onPress={handleLogin}
+        disabled={isLoading}
       >
-        <Text style={styles.buttonText}>Iniciar sesión</Text>
+        <Text style={styles.buttonText}>
+          {isLoading ? "Iniciando sesión..." : "Iniciar sesión"}
+        </Text>
       </TouchableOpacity>
 
       <Text style={styles.orText}>OR</Text>
  
-      <TouchableOpacity style={[styles.buttonAlt, styles.socialButton, { backgroundColor: '#000000' }]}
-      onPress={hola}>
+      <TouchableOpacity
+        style={[styles.buttonAlt, styles.socialButton, { backgroundColor: "#000000" }]}
+        onPress={handleAppleLogin}
+      >
         <Image
           source={require('@/assets/images/apple.png')}
           style={styles.socialIcon}
@@ -195,10 +208,18 @@ const styles = StyleSheet.create({
     color: "#fff",
     fontWeight: "600",
   },
+  buttonDisabled: {
+    opacity: 0.7,
+  },
   orText: {
     fontSize: 16,
     fontWeight: "bold",
     marginVertical: 5,
+  },
+  errorText: {
+    color: "#D32F2F",
+    alignSelf: "flex-start",
+    marginTop: 4,
   },
   socialButton: {
     flexDirection: "row",

--- a/app/(main)/profile.tsx
+++ b/app/(main)/profile.tsx
@@ -1,11 +1,13 @@
 // app/(main)/profile.tsx
 import { Image } from "expo-image";
 import { useRouter } from "expo-router";
-import React from "react";
+import React, { useContext } from "react";
 import { Alert, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { AuthContext } from "../contexts/AuthContext";
 
 export default function Profile() {
   const router = useRouter();
+  const { logout } = useContext(AuthContext);
 
   // Datos de ejemplo — reemplaza por tu estado / store / API
   const user = {
@@ -25,9 +27,14 @@ export default function Profile() {
     Alert.alert("Depositar", "Abrir modal / pantalla de depósito (demo).");
   };
 
-  const handleLogout = () => {
-    // Reemplaza la ruta si tu login está en otra ruta
-    router.replace("/(auth)/login");
+  const handleLogout = async () => {
+    try {
+      await logout();
+    } catch (error) {
+      console.error("Error al cerrar sesión", error);
+    } finally {
+      router.replace("/(auth)/login");
+    }
   };
 
   return (

--- a/app/contexts/AuthContext.tsx
+++ b/app/contexts/AuthContext.tsx
@@ -1,82 +1,152 @@
 // app/contexts/AuthContext.tsx
 import { supabase } from "@/utils/supabase";
-import React, { createContext, useState } from "react";
-
+import type { User } from "@supabase/supabase-js";
+import React, { createContext, useEffect, useState } from "react";
 
 interface AuthContextProps {
-  user: any;
+  user: User | null;
   isLoading: boolean;
   login: (email: string, password: string) => Promise<boolean>;
-  register: (email: string, password: string) => Promise<void>;
-  logout: () => void;
+  register: (email: string, password: string) => Promise<boolean>;
+  logout: () => Promise<void>;
 }
 
-const fakeDataSource = [
-    {
-        email: "test@test.com",
-        password: "12345678",
-        name: "TEST"
-    },
-    {
-        email: "test1@test.com",
-        password: "12345678",
-        name: "TEST"
-    },
-    {
-        email: "test2@test.com",
-        password: "12345678",
-        name: "TEST"
-    },
-    {
-        email: "a",
-        password: "a",
-        name: "a"
-    }
+interface AuthProviderProps {
+  children: React.ReactNode;
+}
 
-]
+export const AuthContext = createContext<AuthContextProps>({
+  user: null,
+  isLoading: false,
+  login: async () => false,
+  register: async () => false,
+  logout: async () => {},
+});
 
-export const AuthContext = createContext({} as AuthContextProps);
-export const AuthProvider = ({ children }: any) => {
-  const [user, setUser] = useState (null);
-  const [isLoading, setIsLoading] = useState(false);
+export const AuthProvider = ({ children }: AuthProviderProps) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
-       /* const login =async (email:string, password:string)=>{
-        for (let index = 0; index < fakeDataSource.length; index++) {
-            if (fakeDataSource[index].email===email && fakeDataSource[index].password===password) {
-               
-                return true;
-            }
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadSession = async () => {
+      try {
+        const { data, error } = await supabase.auth.getSession();
+        if (error) {
+          console.error("Error al obtener la sesión", error.message);
+          return;
         }
-        return false
+
+        if (isMounted) {
+          setUser(data.session?.user ?? null);
+        }
+      } catch (error) {
+        console.error("Error inesperado al obtener la sesión", error);
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    loadSession();
+
+    const { data: authSubscription } = supabase.auth.onAuthStateChange(
+      (_event, session) => {
+        if (isMounted) {
+          setUser(session?.user ?? null);
+        }
+      },
+    );
+
+    return () => {
+      isMounted = false;
+      authSubscription?.subscription.unsubscribe();
+    };
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    setIsLoading(true);
+
+    try {
+      const { data, error } = await supabase.auth.signInWithPassword({
+        email: email.trim(),
+        password,
+      });
+
+      if (error) {
+        console.error("Error al iniciar sesión", error.message);
+        return false;
+      }
+
+      if (data.user) {
+        setUser(data.user);
+      }
+
+      return true;
+    } catch (error) {
+      console.error("Error inesperado al iniciar sesión", error);
+      return false;
+    } finally {
+      setIsLoading(false);
     }
-    */
+  };
 
-    const login = async (email:string, password:string) => {
-        const response = await supabase.auth.signInWithPassword({
-            email,
-            password
-        });
-    return true;
+  const register = async (email: string, password: string) => {
+    setIsLoading(true);
+
+    try {
+      const { data, error } = await supabase.auth.signUp({
+        email: email.trim(),
+        password,
+      });
+
+      if (error) {
+        console.error("Error al registrar usuario", error.message);
+        return false;
+      }
+
+      if (data.user) {
+        setUser(data.user);
+      }
+
+      return true;
+    } catch (error) {
+      console.error("Error inesperado al registrar usuario", error);
+      return false;
+    } finally {
+      setIsLoading(false);
     }
-        
+  };
 
- const register = async () => {
+  const logout = async () => {
+    setIsLoading(true);
 
+    try {
+      const { error } = await supabase.auth.signOut();
+      if (error) {
+        console.error("Error al cerrar sesión", error.message);
+      }
+    } catch (error) {
+      console.error("Error inesperado al cerrar sesión", error);
+    } finally {
+      setUser(null);
+      setIsLoading(false);
     }
+  };
 
-    const logout = async () => {
-        setUser(null);
-    }
-
-    return <AuthContext.Provider
-        value={{
-            user,
-            isLoading,
-            login,
-            register,
-            logout
-        }}
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        isLoading,
+        login,
+        register,
+        logout,
+      }}
     >
-        {children}
+      {children}
     </AuthContext.Provider>
-}
+  );
+};


### PR DESCRIPTION
## Summary
- replace the placeholder auth context with real Supabase session handling for login, register and logout
- improve the login screen to validate inputs, surface errors and disable the button while a request is in flight
- hook the profile screen logout action into Supabase so sessions are cleared when leaving the app

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8b8ff4500832e894ed50876ec7da8