### PR TITLE
feat: enable editing profile data

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -3,12 +3,13 @@ import { Stack } from 'expo-router';
 export default function AuthLayout() {
     return (
         <Stack
-            // initialRouteName='login' //welcome o una pagina 
+            // initialRouteName='login' //welcome o una pagina
             screenOptions={{ headerShown: false }}
         >
             <Stack.Screen name="login" />
             <Stack.Screen name="register" />
             <Stack.Screen name="resetpas" />
+            <Stack.Screen name="editprofile" />
         </Stack>
     );
 }

--- a/app/(auth)/editprofile.tsx
+++ b/app/(auth)/editprofile.tsx
@@ -1,60 +1,245 @@
-import React, { useContext } from "react";
-import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useRouter } from "expo-router";
+import React, { useContext, useEffect, useState } from "react";
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import { AuthContext } from "../contexts/AuthContext";
 
-export default function ProfileScreen() {
-  const { user, logout } = useContext(AuthContext);
+export default function EditProfileScreen() {
+  const router = useRouter();
+  const { user, profile, updateProfile } = useContext(AuthContext);
+  const [fullName, setFullName] = useState("");
+  const [balance, setBalance] = useState("0");
+  const [betsOpen, setBetsOpen] = useState("0");
+  const [winRate, setWinRate] = useState("0");
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    const name =
+      profile?.full_name ??
+      user?.user_metadata?.display_name ??
+      user?.user_metadata?.full_name ??
+      "";
+    setFullName(name);
+    if (profile?.balance !== undefined && profile?.balance !== null) {
+      setBalance(String(profile.balance));
+    }
+    if (profile?.bets_open !== undefined && profile?.bets_open !== null) {
+      setBetsOpen(String(profile.bets_open));
+    }
+    if (profile?.win_rate !== undefined && profile?.win_rate !== null) {
+      setWinRate(String(profile.win_rate));
+    }
+  }, [profile, user]);
+
+  const parseDecimal = (value: string) => {
+    const normalized = value.replace(/,/g, ".");
+    const parsed = parseFloat(normalized);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  };
+
+  const parseInteger = (value: string) => {
+    const parsed = parseInt(value, 10);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  };
+
+  const handleSave = async () => {
+    if (!user?.id) {
+      Alert.alert("Error", "Necesitas iniciar sesión para editar tu perfil.");
+      return;
+    }
+
+    const fullNameTrimmed = fullName.trim();
+    if (!fullNameTrimmed) {
+      Alert.alert("Error", "El nombre no puede estar vacío.");
+      return;
+    }
+
+    setIsSaving(true);
+    const success = await updateProfile({
+      full_name: fullNameTrimmed,
+      balance: parseDecimal(balance),
+      bets_open: parseInteger(betsOpen),
+      win_rate: parseDecimal(winRate),
+    });
+    setIsSaving(false);
+
+    if (!success) {
+      Alert.alert("Error", "No se pudo actualizar tu perfil. Intenta nuevamente.");
+      return;
+    }
+
+    Alert.alert("Perfil actualizado", "Se guardaron tus cambios correctamente.", [
+      {
+        text: "Aceptar",
+        onPress: () => router.back(),
+      },
+    ]);
+  };
+
+  if (!user) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.centeredText}>Inicia sesión para editar tu perfil.</Text>
+        <TouchableOpacity style={styles.secondaryButton} onPress={() => router.replace("/(auth)/login")}>
+          <Text style={styles.secondaryButtonText}>Ir a iniciar sesión</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
 
   return (
-    <View style={styles.container}>
-      <Image
-        source={require("@/assets/images/Logo.png")}
-        style={styles.avatar}
-      />
-      <Text style={styles.name}>{user?.user_metadata?.full_name || "Usuario"}</Text>
-      <Text style={styles.email}>{user?.email}</Text>
-      <TouchableOpacity style={styles.button} onPress={logout}>
-        <Text style={styles.buttonText}>Cerrar sesión</Text>
-      </TouchableOpacity>
-    </View>
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.select({ ios: "padding", android: undefined })}
+    >
+      <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+        <Text style={styles.title}>Editar perfil</Text>
+        <Text style={styles.subtitle}>
+          Modifica tus datos visibles y la información que se muestra en tu perfil.
+        </Text>
+
+        <View style={styles.field}>
+          <Text style={styles.label}>Nombre para mostrar</Text>
+          <TextInput
+            style={styles.input}
+            value={fullName}
+            onChangeText={setFullName}
+            placeholder="Nombre completo"
+            autoCapitalize="words"
+          />
+        </View>
+
+        <View style={styles.field}>
+          <Text style={styles.label}>Saldo</Text>
+          <TextInput
+            style={styles.input}
+            value={balance}
+            onChangeText={setBalance}
+            placeholder="0"
+            keyboardType="decimal-pad"
+          />
+        </View>
+
+        <View style={styles.field}>
+          <Text style={styles.label}>Apuestas abiertas</Text>
+          <TextInput
+            style={styles.input}
+            value={betsOpen}
+            onChangeText={setBetsOpen}
+            placeholder="0"
+            keyboardType="number-pad"
+          />
+        </View>
+
+        <View style={styles.field}>
+          <Text style={styles.label}>Win rate (%)</Text>
+          <TextInput
+            style={styles.input}
+            value={winRate}
+            onChangeText={setWinRate}
+            placeholder="0"
+            keyboardType="decimal-pad"
+          />
+        </View>
+
+        <TouchableOpacity
+          style={[styles.button, isSaving && styles.buttonDisabled]}
+          onPress={handleSave}
+          disabled={isSaving}
+        >
+          <Text style={styles.buttonText}>{isSaving ? "Guardando..." : "Guardar cambios"}</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity style={styles.secondaryButton} onPress={() => router.back()} disabled={isSaving}>
+          <Text style={styles.secondaryButtonText}>Cancelar</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
+    backgroundColor: "#F8FBF8",
+  },
+  content: {
     padding: 24,
+    paddingTop: 80,
+    gap: 16,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: "800",
+    color: "#0F3D12",
+  },
+  subtitle: {
+    color: "#3A6F3A",
+    fontSize: 14,
+  },
+  field: {
+    gap: 8,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#145A32",
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: "#CFE8D2",
+    borderRadius: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
     backgroundColor: "#fff",
-  },
-  avatar: {
-    width: 100,
-    height: 100,
-    borderRadius: 50,
-    marginBottom: 24,
-    resizeMode: "contain",
-  },
-  name: {
-    fontSize: 24,
-    fontWeight: "bold",
-    marginBottom: 8,
-  },
-  email: {
     fontSize: 16,
-    color: "#888",
-    marginBottom: 24,
   },
   button: {
-    backgroundColor: "#4CAF50",
-    padding: 12,
-    borderRadius: 8,
+    backgroundColor: "#2E7D32",
+    paddingVertical: 14,
+    borderRadius: 10,
     alignItems: "center",
-    width: "80%",
+  },
+  buttonDisabled: {
+    opacity: 0.7,
   },
   buttonText: {
     color: "#fff",
-    fontWeight: "bold",
+    fontWeight: "700",
     fontSize: 16,
+  },
+  secondaryButton: {
+    marginTop: 8,
+    paddingVertical: 12,
+    borderRadius: 10,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#2E7D32",
+  },
+  secondaryButtonText: {
+    color: "#2E7D32",
+    fontWeight: "700",
+  },
+  centered: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+    gap: 16,
+    backgroundColor: "#F8FBF8",
+  },
+  centeredText: {
+    fontSize: 16,
+    color: "#145A32",
+    textAlign: "center",
   },
 });

--- a/app/(main)/profile.tsx
+++ b/app/(main)/profile.tsx
@@ -1,25 +1,48 @@
 // app/(main)/profile.tsx
 import { Image } from "expo-image";
-import { Link, useRouter } from "expo-router";
-import React, { useContext } from "react";
+import { useRouter } from "expo-router";
+import React, { useContext, useEffect } from "react";
 import { Alert, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { AuthContext } from "../contexts/AuthContext";
 
 export default function Profile() {
   const router = useRouter();
-  const { logout } = useContext(AuthContext);
+  const { user, profile, refreshProfile, logout } = useContext(AuthContext);
 
-  // Datos de ejemplo — reemplaza por tu estado / store / API
-  const user = {
-    name: "Juan Cruz",
-    email: "juan.cruz@example.com",
-    avatar: require("../../assets/images/R.jpg"),
-    balance: 600.000,
-    betsOpen: 3,
-    winRate: 58,
+  useEffect(() => {
+    if (user && !profile) {
+      refreshProfile();
+    }
+  }, [user, profile, refreshProfile]);
+
+  const displayName =
+    profile?.full_name ??
+    user?.user_metadata?.display_name ??
+    user?.user_metadata?.full_name ??
+    user?.email ??
+    "Usuario";
+
+  const email = user?.email ?? "Sin correo";
+
+  const toNumber = (value: number | string | null | undefined) => {
+    if (value === null || value === undefined) {
+      return 0;
+    }
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
   };
 
+  const balanceValue = toNumber(profile?.balance);
+  const openBetsValue = toNumber(profile?.bets_open);
+  const winRateValue = toNumber(profile?.win_rate);
 
+  const formattedBalance = !Number.isNaN(balanceValue)
+    ? balanceValue.toLocaleString(undefined, { minimumFractionDigits: 2 })
+    : "0.00";
+
+  const avatarSource = profile?.avatar_url
+    ? { uri: profile.avatar_url }
+    : require("../../assets/images/R.jpg");
 
   const handleDeposit = () => {
     Alert.alert("Depositar", "Abrir modal / pantalla de depósito (demo).");
@@ -36,17 +59,17 @@ export default function Profile() {
   };
 
   const handleEdit = () => {
-    Alert.alert("Editar perfil", "Aquí iría la pantalla de edición (demo).");
+    router.push("/(auth)/editprofile");
   };
 
   return (
     <View style={styles.container}>
       {/* Header */}
       <View style={styles.header}>
-        <Image source={user.avatar} style={styles.avatar} contentFit="cover" />
+        <Image source={avatarSource} style={styles.avatar} contentFit="cover" />
         <View style={styles.headerText}>
-          <Text style={styles.name}>{user.name}</Text>
-          <Text style={styles.email}>{user.email}</Text>
+          <Text style={styles.name}>{displayName}</Text>
+          <Text style={styles.email}>{email}</Text>
         </View>
       </View>
 
@@ -54,17 +77,17 @@ export default function Profile() {
       <View style={styles.card}>
         <Text style={styles.cardTitle}>Saldo</Text>
         <Text style={styles.balance}>
-          ${user.balance.toLocaleString(undefined, { minimumFractionDigits: 2 })}
+          ${formattedBalance}
         </Text>
 
         <View style={styles.kpiRow}>
           <View style={styles.kpi}>
-            <Text style={styles.kpiNum}>{user.betsOpen}</Text>
+            <Text style={styles.kpiNum}>{openBetsValue}</Text>
             <Text style={styles.kpiLabel}>Apuestas</Text>
           </View>
 
           <View style={styles.kpi}>
-            <Text style={styles.kpiNum}>{user.winRate}%</Text>
+            <Text style={styles.kpiNum}>{winRateValue}%</Text>
             <Text style={styles.kpiLabel}>Win rate</Text>
           </View>
         </View>
@@ -73,11 +96,9 @@ export default function Profile() {
           <TouchableOpacity style={styles.primaryBtn} onPress={handleDeposit}>
             <Text style={styles.primaryBtnText}>Depositar</Text>
           </TouchableOpacity>
-          <Link href="/(auth)/editprofile" asChild>
-            <TouchableOpacity style={styles.outlineBtn}>
-              <Text style={styles.outlineBtnText}>Editar perfil</Text>
-            </TouchableOpacity>
-          </Link>
+          <TouchableOpacity style={styles.outlineBtn} onPress={handleEdit}>
+            <Text style={styles.outlineBtnText}>Editar perfil</Text>
+          </TouchableOpacity>
         </View>
       </View>
 

--- a/app/contexts/AuthContext.tsx
+++ b/app/contexts/AuthContext.tsx
@@ -1,125 +1,245 @@
-// app/contexts/AuthContext.tsx
+import React, { createContext, useCallback, useState } from "react";
 import { supabase } from "@/utils/supabase";
-import React, { createContext, useState } from "react";
 
-
+interface Profile {
+  id: string;
+  full_name?: string | null;
+  balance?: number | null;
+  bets_open?: number | null;
+  win_rate?: number | null;
+  avatar_url?: string | null;
+}
 
 interface AuthContextProps {
   user: any;
+  profile: Profile | null;
   isLoading: boolean;
   login: (email: string, password: string) => Promise<boolean>;
   register: (email: string, password: string, fullName?: string) => Promise<boolean>;
-  logout: () => void;
+  updateProfile: (values: {
+    full_name?: string;
+    balance?: number;
+    bets_open?: number;
+    win_rate?: number;
+  }) => Promise<boolean>;
+  refreshProfile: () => Promise<void>;
+  logout: () => Promise<void>;
 }
 
-const fakeDataSource = [
-    {
-        email: "test@test.com",
-        password: "12345678",
-        name: "TEST"
-    },
-    {
-        email: "test1@test.com",
-        password: "12345678",
-        name: "TEST"
-    },
-    {
-        email: "test2@test.com",
-        password: "12345678",
-        name: "TEST"
-    },
-    {
-        email: "a",
-        password: "a",
-        name: "a"
-    }
-
-]
-
 export const AuthContext = createContext({} as AuthContextProps);
-export const AuthProvider = ({ children }: any) => {
-  const [user, setUser] = useState<null | any>(null);
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [user, setUser] = useState<any>(null);
+  const [profile, setProfile] = useState<Profile | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
-       /* const login =async (email:string, password:string)=>{
-        for (let index = 0; index < fakeDataSource.length; index++) {
-            if (fakeDataSource[index].email===email && fakeDataSource[index].password===password) {
-               
-                return true;
-            }
-        }
-        return false
+  const fetchProfile = useCallback(async (authUser: any) => {
+    if (!authUser?.id) {
+      setProfile(null);
+      return null;
     }
-    */
 
-    const login = async (email:string, password:string) => {
-        const { data, error } = await supabase.auth.signInWithPassword({
-          email,
-          password,
-        });
-        const supabaseResponse = await supabase
-        .from("profiles")
-        .select()
-       // .eq("id", response.data.user.id)
-        setUser(supabaseResponse.data);
+    const { data: profileData, error: profileError } = await supabase
+      .from("profiles")
+      .select("*")
+      .eq("id", authUser.id)
+      .single();
 
-        if (error || !data.user) {
-          return false;
+    if (profileError) {
+      if ((profileError as any)?.code === "PGRST116") {
+        const defaultProfile: Profile = {
+          id: authUser.id,
+          full_name:
+            authUser?.user_metadata?.display_name ||
+            authUser?.user_metadata?.full_name ||
+            authUser?.email ||
+            "",
+          balance: 0,
+          bets_open: 0,
+          win_rate: 0,
+        };
+
+        const { data: createdProfile, error: createError } = await supabase
+          .from("profiles")
+          .upsert(defaultProfile)
+          .select("*")
+          .single();
+
+        if (!createError && createdProfile) {
+          setProfile(createdProfile);
+          return createdProfile;
         }
-        if (data.user) {
-            setUser(data.user);
-        }
-        return true;
-      };
 
- const register = async (email: string, password: string, fullName?: string) => {
-    // const supabaseResponse = await supabase
-    // .from('profiles')
-    // .insert({ 
-    //     id: response.data.user?.id,
-    //     full_name: fullName
+        console.error("Error creando perfil por defecto", createError);
+        return null;
+      }
 
-    //const updateUser = (params: string) => {
-    //   const supabaseResponse = await supabase
-    //   .from("profiles")
-    //   .update({ full_name: params })
-    //   .eq("id", response.data.user.id)
-    //   setUser(supabaseResponse.data);
-    // }
+      console.error("Error obteniendo perfil", profileError);
+      return null;
+    }
+
+    setProfile(profileData);
+    return profileData;
+  }, []);
+
+  const login = async (email: string, password: string) => {
     setIsLoading(true);
-    try{
-        const { data, error } = await supabase.auth.signUp({
-            email,
-            password,
-            options: fullName
-          ? {
-              data: { full_name: fullName },
-            }
-          : undefined,
+    try {
+      const { data, error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
       });
+
       if (error || !data.user) {
+        console.error("Error al iniciar sesión", error);
         return false;
       }
+
+      setUser(data.user);
+      await fetchProfile(data.user);
       return true;
+    } catch (err) {
+      console.error("Error inesperado al iniciar sesión", err);
+      return false;
     } finally {
       setIsLoading(false);
     }
   };
 
-    const logout = async () => {
-        setUser(null);
+  const register = async (email: string, password: string, fullName?: string) => {
+    setIsLoading(true);
+    try {
+      const { data, error } = await supabase.auth.signUp({
+        email,
+        password,
+        options: fullName
+          ? {
+              data: { full_name: fullName, display_name: fullName },
+            }
+          : undefined,
+      });
+
+      if (error || !data.user) {
+        console.error("Error al registrar usuario", error);
+        return false;
+      }
+
+      const baseProfile: Profile = {
+        id: data.user.id,
+        full_name: fullName || data.user.email,
+        balance: 0,
+        bets_open: 0,
+        win_rate: 0,
+      };
+
+      const { error: profileError } = await supabase.from("profiles").upsert(baseProfile);
+      if (profileError) {
+        console.error("No se pudo crear el perfil", profileError);
+      }
+
+      if (fullName) {
+        const display = fullName.trim();
+        if (display) {
+          const { error: updateError } = await supabase.auth.updateUser({
+            data: { display_name: display, full_name: display },
+          });
+          if (updateError) {
+            console.error("No se pudo actualizar el nombre visible", updateError);
+          }
+        }
+      }
+
+      return true;
+    } catch (err) {
+      console.error("Error inesperado al registrar", err);
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const updateProfile = async (values: {
+    full_name?: string;
+    balance?: number;
+    bets_open?: number;
+    win_rate?: number;
+  }) => {
+    if (!user?.id) {
+      return false;
     }
 
-    return <AuthContext.Provider
-        value={{
-            user,
-            isLoading,
-            login,
-            register,
-            logout
-        }}
-    >
-        {children}
-    </AuthContext.Provider>
+    const payload = {
+      id: user.id,
+      ...values,
+      updated_at: new Date().toISOString(),
+    };
 
+    const { data: updatedProfile, error } = await supabase
+      .from("profiles")
+      .upsert(payload)
+      .select("*")
+      .single();
+
+    if (error) {
+      console.error("No se pudo actualizar el perfil", error);
+      return false;
+    }
+
+    if (values.full_name) {
+      const display = values.full_name.trim();
+      if (display) {
+        const { error: updateError } = await supabase.auth.updateUser({
+          data: { display_name: display, full_name: display },
+        });
+        if (updateError) {
+          console.error("No se pudo actualizar el nombre visible", updateError);
+        } else {
+          setUser((prev: any) =>
+            prev
+              ? {
+                  ...prev,
+                  user_metadata: {
+                    ...prev.user_metadata,
+                    display_name: display,
+                    full_name: display,
+                  },
+                }
+              : prev,
+          );
+        }
+      }
+    }
+
+    setProfile(updatedProfile);
+    return true;
+  };
+
+  const refreshProfile = useCallback(async () => {
+    if (user) {
+      await fetchProfile(user);
+    }
+  }, [user, fetchProfile]);
+
+  const logout = async () => {
+    await supabase.auth.signOut();
+    setUser(null);
+    setProfile(null);
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        profile,
+        isLoading,
+        login,
+        register,
+        updateProfile,
+        refreshProfile,
+        logout,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
 };


### PR DESCRIPTION
## Summary
- fetch and persist extended profile information through the auth context
- build an edit profile screen that updates Supabase profile fields and auth display name
- show live profile data on the profile screen and navigate to the new editor

## Testing
- npm run lint *(fails: expo CLI unavailable in container)*
- npx expo lint *(fails: npm registry access restricted in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f160d880832e87b34438fff437de